### PR TITLE
Update disasm_ami.py error handling

### DIFF
--- a/scripts/disasm_ami.py
+++ b/scripts/disasm_ami.py
@@ -7,7 +7,12 @@ if len(sys.argv) < 2:
     sys.exit(1)
 
 bios_path = Path(sys.argv[1])
-lines = int(sys.argv[2]) if len(sys.argv) > 2 else 64
+
+try:
+    lines = int(sys.argv[2]) if len(sys.argv) > 2 else None
+except ValueError:
+    print("Second argument must be an integer (number of lines).")
+    sys.exit(1)
 
 if not bios_path.exists():
     print(f"File {bios_path} not found")
@@ -20,6 +25,6 @@ if proc.returncode != 0:
     sys.exit(proc.returncode)
 
 for i, line in enumerate(proc.stdout.splitlines()):
-    if i >= lines:
+    if lines is not None and i >= lines:
         break
     print(line)


### PR DESCRIPTION
## Summary
- improve the `disasm_ami.py` helper script to validate line argument
- allow dumping full disassembly when the line count is omitted

## Testing
- `python3 -m py_compile scripts/disasm_ami.py`
- `cargo test --target x86_64-pc-windows-gnu` *(fails: cannot compile simple-whp-demo)*

------
https://chatgpt.com/codex/tasks/task_e_6878bdafb33c832cafc90c504ac54097