### PR TITLE
Add BIOS debug logging

### DIFF
--- a/SimpleWhpDemo/main.c
+++ b/SimpleWhpDemo/main.c
@@ -525,6 +525,14 @@ int main(int argc, char* argv[], char* envp[])
                                         mem[0xFFFF4] = 0xF0;
                                 }
                         }
+                        if (LoadIvtFwResult)
+                        {
+                                PUCHAR mem = (PUCHAR)VirtualMemory;
+                                printf("BIOS loaded from %s (%lu bytes)\n", BiosFileName, BiosSize);
+                                printf("Reset vector bytes: %02X %02X %02X %02X %02X\n",
+                                       mem[0xFFFF0], mem[0xFFFF1], mem[0xFFFF2],
+                                       mem[0xFFFF3], mem[0xFFFF4]);
+                        }
                         if (LoadIvtFwResult && BiosSize < 0x10000)
                                 MirrorBiosRegion(0xF0000, BiosSize);
                         BOOL LoadDiskResult = LoadDiskImage("disk.img");


### PR DESCRIPTION
## Summary
- print BIOS file name, size, and reset vector bytes after loading BIOS

## Testing
- `cargo test --quiet` *(fails: could not compile `simple-whp-demo` due to missing windows crate)*
- `cargo test --target x86_64-pc-windows-gnu --quiet` *(fails: cannot compile windows crate)*

------
https://chatgpt.com/codex/tasks/task_e_6878eafb7f20832cae5cd1c40f9bd4be