### PR TITLE
Add CGA mode control port

### DIFF
--- a/SimpleWhpDemo/main.c
+++ b/SimpleWhpDemo/main.c
@@ -269,6 +269,7 @@ static UINT32 UnknownPortCount = 0;
 static UCHAR PicMasterImr = 0;
 static UCHAR PicSlaveImr = 0;
 static UCHAR SysCtrl = 0;
+static UCHAR CgaMode = 0;
 
 BOOL LoadDiskImage(PCSTR FileName)
 {
@@ -294,6 +295,7 @@ static const char* GetPortName(USHORT port)
         case IO_PORT_PIC_SLAVE_CMD:   return "PIC_SLAVE_CMD";
         case IO_PORT_PIC_SLAVE_DATA:  return "PIC_SLAVE_DATA";
         case IO_PORT_SYS_CTRL:        return "SYS_CTRL";
+        case IO_PORT_CGA_MODE:        return "CGA_MODE";
         default:                   return "UNKNOWN";
         }
 }
@@ -334,6 +336,11 @@ HRESULT SwEmulatorIoCallback(IN PVOID Context, IN OUT WHV_EMULATOR_IO_ACCESS_INF
                else if (IoAccess->Port == IO_PORT_SYS_CTRL)
                {
                        IoAccess->Data = SysCtrl;
+                       return S_OK;
+               }
+               else if (IoAccess->Port == IO_PORT_CGA_MODE)
+               {
+                       IoAccess->Data = CgaMode;
                        return S_OK;
                }
                else if (IoAccess->Port == IO_PORT_PIC_MASTER_DATA)
@@ -381,6 +388,11 @@ HRESULT SwEmulatorIoCallback(IN PVOID Context, IN OUT WHV_EMULATOR_IO_ACCESS_INF
         else if (IoAccess->Port == IO_PORT_SYS_CTRL)
         {
                 SysCtrl = (UCHAR)IoAccess->Data;
+                return S_OK;
+        }
+        else if (IoAccess->Port == IO_PORT_CGA_MODE)
+        {
+                CgaMode = (UCHAR)IoAccess->Data;
                 return S_OK;
         }
         else if (IoAccess->Port == IO_PORT_PIC_MASTER_CMD)

--- a/SimpleWhpDemo/vmdef.h
+++ b/SimpleWhpDemo/vmdef.h
@@ -12,6 +12,7 @@
 #define IO_PORT_SYS_CTRL        0x0061
 #define IO_PORT_PIC_SLAVE_CMD   0x00A0
 #define IO_PORT_PIC_SLAVE_DATA  0x00A1
+#define IO_PORT_CGA_MODE        0x03D8
 
 // Hypervisor Capability.
 BOOL HypervisorPresence;

--- a/readme.md
+++ b/readme.md
@@ -48,6 +48,7 @@ emulator logs each I/O access so you can observe the guest's behavior.
 | `0x00FF` | Disk data port backed by `disk.img`. Reads/writes stream sequential bytes. |
 | `0x0080` | POST/IO‑delay port. Writes are ignored but recorded in the log. |
 | `0x0061` | System control port used for speaker and NMI masking. |
+| `0x03D8` | CGA mode control register. Reads return the last value written. |
 | other | Any other port triggers an `Unknown I/O Port` message. Repeated access to the same unknown port terminates the program. |
 
 Example to assemble and run the keyboard demo on Windows:

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,7 @@ const IO_PORT_PIC_MASTER_DATA:u16=0x0021;
 const IO_PORT_PIC_SLAVE_CMD:u16=0x00A0;
 const IO_PORT_PIC_SLAVE_DATA:u16=0x00A1;
 const IO_PORT_SYS_CTRL:u16=0x0061;
+const IO_PORT_CGA_MODE:u16=0x03D8;
 
 fn port_name(port:u16)->&'static str
 {
@@ -44,6 +45,7 @@ fn port_name(port:u16)->&'static str
         IO_PORT_PIC_SLAVE_CMD=>"PIC_SLAVE_CMD",
         IO_PORT_PIC_SLAVE_DATA=>"PIC_SLAVE_DATA",
         IO_PORT_SYS_CTRL=>"SYS_CTRL",
+        IO_PORT_CGA_MODE=>"CGA_MODE",
         _=>"UNKNOWN"
     }
 }
@@ -56,6 +58,7 @@ static mut UNKNOWN_PORT_COUNT:u32=0;
 static mut PIC_MASTER_IMR:u8=0;
 static mut PIC_SLAVE_IMR:u8=0;
 static mut SYS_CTRL:u8=0;
+static mut CGA_MODE:u8=0;
 
 const CGA_COLS:usize=80;
 const CGA_ROWS:usize=25;
@@ -457,6 +460,11 @@ unsafe extern "system" fn emu_io_port_callback(_context:*const c_void,io_access:
                                 (*io_access).Data = SYS_CTRL as u32;
                                 S_OK
                         }
+                        else if (*io_access).Port==IO_PORT_CGA_MODE
+                        {
+                                (*io_access).Data = CGA_MODE as u32;
+                                S_OK
+                        }
                         else if (*io_access).Port==IO_PORT_PIC_MASTER_DATA
                         {
                                 (*io_access).Data = PIC_MASTER_IMR as u32;
@@ -507,6 +515,11 @@ unsafe extern "system" fn emu_io_port_callback(_context:*const c_void,io_access:
                         else if (*io_access).Port==IO_PORT_SYS_CTRL
                         {
                                 SYS_CTRL = (*io_access).Data as u8;
+                                S_OK
+                        }
+                        else if (*io_access).Port==IO_PORT_CGA_MODE
+                        {
+                                CGA_MODE = (*io_access).Data as u8;
                                 S_OK
                         }
                         else if (*io_access).Port==IO_PORT_PIC_MASTER_CMD


### PR DESCRIPTION
## Summary
- recognize CGA mode control port in the C implementation
- store value written to `0x03D8` and return it on reads

## Testing
- `cargo check` *(fails: could not compile `simple-whp-demo` due to missing Windows APIs)*
- `cargo check --target x86_64-pc-windows-gnu` *(fails: target may not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_6878f25ce8ac832c8baff1d02a4fa809