### PR TITLE
Implement DMA port stub

### DIFF
--- a/SimpleWhpDemo/main.c
+++ b/SimpleWhpDemo/main.c
@@ -203,10 +203,21 @@ HRESULT SwEmulatorIoCallback(IN PVOID Context, IN OUT WHV_EMULATOR_IO_ACCESS_INF
                         }
                         return S_OK;
                 }
+                else if (IoAccess->Port == IO_PORT_DMA_PAGE_CH3)
+                {
+                        ((PUCHAR)&IoAccess->Data)[0] = DmaPageCh3;
+                        return S_OK;
+                }
                 puts("Input is not implemented!");
                 return E_NOTIMPL;
         }
-        if (IoAccess->Port == IO_PORT_STRING_PRINT)
+        if (IoAccess->Port == IO_PORT_DMA_PAGE_CH3)
+        {
+                if (IoAccess->AccessSize > 0)
+                        DmaPageCh3 = ((PUCHAR)&IoAccess->Data)[0];
+                return S_OK;
+        }
+        else if (IoAccess->Port == IO_PORT_STRING_PRINT)
         {
                 for (UINT8 i = 0; i < IoAccess->AccessSize; i++)
                         putc(((PUCHAR)&IoAccess->Data)[i], stdout);

--- a/SimpleWhpDemo/vmdef.h
+++ b/SimpleWhpDemo/vmdef.h
@@ -5,6 +5,8 @@
 
 #define IO_PORT_STRING_PRINT	0x0000
 #define IO_PORT_KEYBOARD_INPUT	0x0001
+#define IO_PORT_DMA_PAGE_CH3	0x0083
+UCHAR DmaPageCh3 = 0;
 
 // Hypervisor Capability.
 BOOL HypervisorPresence;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,17 +7,20 @@ use aligned::*;
 static GLOBAL_EMULATOR_HANDLE:AtomicPtr<c_void>=AtomicPtr::new(null_mut());
 static GLOBAL_EMULATOR_CALLBACKS:WHV_EMULATOR_CALLBACKS=WHV_EMULATOR_CALLBACKS
 {
-	Size:size_of::<WHV_EMULATOR_CALLBACKS>() as u32,
-	Reserved:0,
-	WHvEmulatorIoPortCallback:Some(emu_io_port_callback),
-	WHvEmulatorMemoryCallback:Some(emu_memory_callback),
-	WHvEmulatorGetVirtualProcessorRegisters:Some(emu_get_vcpu_reg_callback),
-	WHvEmulatorSetVirtualProcessorRegisters:Some(emu_set_vcpu_reg_callback),
+        Size:size_of::<WHV_EMULATOR_CALLBACKS>() as u32,
+        Reserved:0,
+        WHvEmulatorIoPortCallback:Some(emu_io_port_callback),
+        WHvEmulatorMemoryCallback:Some(emu_memory_callback),
+        WHvEmulatorGetVirtualProcessorRegisters:Some(emu_get_vcpu_reg_callback),
+        WHvEmulatorSetVirtualProcessorRegisters:Some(emu_set_vcpu_reg_callback),
         WHvEmulatorTranslateGvaPage:Some(emu_translate_gva_callback)
 };
 
+static mut DMA_PAGE_CH3:u8=0;
+
 const IO_PORT_STRING_PRINT:u16=0x0000;
 const IO_PORT_KEYBOARD_INPUT:u16=0x0001;
+const IO_PORT_DMA_PAGE_CH3:u16=0x0083;
 
 const INITIAL_VCPU_COUNT:usize=40;
 const INITIAL_VCPU_REGISTER_NAMES:[WHV_REGISTER_NAME;INITIAL_VCPU_COUNT]=
@@ -300,6 +303,21 @@ unsafe extern "system" fn emu_io_port_callback(_context:*const c_void,io_access:
                                 println!("Input is not implemented!");
                                 E_NOTIMPL
                         }
+                }
+                else if (*io_access).Port==IO_PORT_DMA_PAGE_CH3
+                {
+                        if (*io_access).Direction==0
+                        {
+                                (*io_access).Data=(unsafe{DMA_PAGE_CH3}) as u64;
+                        }
+                        else
+                        {
+                                if (*io_access).AccessSize>0
+                                {
+                                        unsafe{DMA_PAGE_CH3=(((*io_access).Data)&0xFF) as u8;}
+                                }
+                        }
+                        S_OK
                 }
                 else if (*io_access).Port==IO_PORT_STRING_PRINT
                 {


### PR DESCRIPTION
## Summary
- add constant and backing variable for DMA page register (port 0x83)
- emulate reads/writes to port 0x83 in both C and Rust versions

## Testing
- `cargo build --quiet` *(fails: could not compile `simple-whp-demo`)*

------
https://chatgpt.com/codex/tasks/task_e_6878f5928b9c832ca023220841c335a9