### PR TITLE
Add basic PIT control port emulation

### DIFF
--- a/SimpleWhpDemo/main.c
+++ b/SimpleWhpDemo/main.c
@@ -212,6 +212,11 @@ HRESULT SwEmulatorIoCallback(IN PVOID Context, IN OUT WHV_EMULATOR_IO_ACCESS_INF
                         putc(((PUCHAR)&IoAccess->Data)[i], stdout);
                 return S_OK;
         }
+        else if (IoAccess->Port == IO_PORT_PIT_CONTROL)
+        {
+                // Ignore PIT control register writes.
+                return S_OK;
+        }
         else
         {
                 printf("Unknown I/O Port: 0x%04X is accessed!\n", IoAccess->Port);

--- a/SimpleWhpDemo/vmdef.h
+++ b/SimpleWhpDemo/vmdef.h
@@ -5,6 +5,7 @@
 
 #define IO_PORT_STRING_PRINT	0x0000
 #define IO_PORT_KEYBOARD_INPUT	0x0001
+#define IO_PORT_PIT_CONTROL     0x0043
 
 // Hypervisor Capability.
 BOOL HypervisorPresence;

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ static GLOBAL_EMULATOR_CALLBACKS:WHV_EMULATOR_CALLBACKS=WHV_EMULATOR_CALLBACKS
 
 const IO_PORT_STRING_PRINT:u16=0x0000;
 const IO_PORT_KEYBOARD_INPUT:u16=0x0001;
+const IO_PORT_PIT_CONTROL:u16=0x0043;
 
 const INITIAL_VCPU_COUNT:usize=40;
 const INITIAL_VCPU_REGISTER_NAMES:[WHV_REGISTER_NAME;INITIAL_VCPU_COUNT]=
@@ -308,6 +309,11 @@ unsafe extern "system" fn emu_io_port_callback(_context:*const c_void,io_access:
                                 let ch=(((*io_access).Data>>(i*8)) as u8) as char;
                                 print!("{}",ch);
                         }
+                        S_OK
+                }
+                else if (*io_access).Port==IO_PORT_PIT_CONTROL
+                {
+                        // Ignore PIT control register writes.
                         S_OK
                 }
                 else


### PR DESCRIPTION
## Summary
- support PIT control port (0x0043) in both Rust and C implementations
- ignore PIT control register writes so execution can continue

## Testing
- `cargo build --release` *(fails: could not compile `simple-whp-demo` due to missing `windows` crate for target environment)*

------
https://chatgpt.com/codex/tasks/task_e_6878fddda93c832caf522877bed65907