### PR TITLE
Handle PIT control port

### DIFF
--- a/SimpleWhpDemo/main.c
+++ b/SimpleWhpDemo/main.c
@@ -271,6 +271,7 @@ static UCHAR PicSlaveImr = 0;
 static UCHAR SysCtrl = 0;
 static UCHAR CgaMode = 0;
 static UCHAR MdaMode = 0;
+static UCHAR PitControl = 0;
 
 BOOL LoadDiskImage(PCSTR FileName)
 {
@@ -301,6 +302,7 @@ static const char* GetPortName(USHORT port)
         case IO_PORT_DMA_PAGE3:       return "DMA_PAGE3";
         case IO_PORT_VIDEO_MISC_B8:   return "VIDEO_MISC_B8";
         case IO_PORT_SPECIAL_213:     return "PORT_213";
+        case IO_PORT_PIT_CONTROL:     return "PIT_CONTROL";
         case IO_PORT_PIT_CMD:         return "PIT_CMD";
         case IO_PORT_TIMER_MISC:      return "TIMER_MISC";
         default:                   return "UNKNOWN";
@@ -355,6 +357,11 @@ HRESULT SwEmulatorIoCallback(IN PVOID Context, IN OUT WHV_EMULATOR_IO_ACCESS_INF
                        IoAccess->Data = CgaMode;
                        return S_OK;
                }
+               else if (IoAccess->Port == IO_PORT_PIT_CONTROL)
+               {
+                       IoAccess->Data = PitControl;
+                       return S_OK;
+               }
                else if (IoAccess->Port == IO_PORT_PIC_MASTER_DATA)
                {
                        IoAccess->Data = PicMasterImr;
@@ -374,6 +381,7 @@ HRESULT SwEmulatorIoCallback(IN PVOID Context, IN OUT WHV_EMULATOR_IO_ACCESS_INF
                         IoAccess->Port == IO_PORT_VIDEO_MISC_B8 ||
                         IoAccess->Port == IO_PORT_SPECIAL_213 ||
                         IoAccess->Port == IO_PORT_PIT_CMD ||
+                        IoAccess->Port == IO_PORT_PIT_CONTROL ||
                         IoAccess->Port == IO_PORT_TIMER_MISC)
                {
                        IoAccess->Data = 0;
@@ -421,7 +429,12 @@ HRESULT SwEmulatorIoCallback(IN PVOID Context, IN OUT WHV_EMULATOR_IO_ACCESS_INF
                CgaMode = (UCHAR)IoAccess->Data;
                return S_OK;
        }
-        else if (IoAccess->Port == IO_PORT_PIC_MASTER_CMD)
+       else if (IoAccess->Port == IO_PORT_PIT_CONTROL)
+       {
+               PitControl = (UCHAR)IoAccess->Data;
+               return S_OK;
+       }
+       else if (IoAccess->Port == IO_PORT_PIC_MASTER_CMD)
         {
                 PicMasterImr = (UCHAR)IoAccess->Data; /* treat command as IMR for simplicity */
                 return S_OK;
@@ -445,6 +458,7 @@ HRESULT SwEmulatorIoCallback(IN PVOID Context, IN OUT WHV_EMULATOR_IO_ACCESS_INF
                  IoAccess->Port == IO_PORT_VIDEO_MISC_B8 ||
                  IoAccess->Port == IO_PORT_SPECIAL_213 ||
                  IoAccess->Port == IO_PORT_PIT_CMD ||
+                 IoAccess->Port == IO_PORT_PIT_CONTROL ||
                  IoAccess->Port == IO_PORT_TIMER_MISC)
         {
                 /* Ports touched by the BIOS during POST but not modeled. */

--- a/SimpleWhpDemo/vmdef.h
+++ b/SimpleWhpDemo/vmdef.h
@@ -18,6 +18,7 @@
 #define IO_PORT_VIDEO_MISC_B8   0x00B8
 #define IO_PORT_SPECIAL_213     0x0213
 #define IO_PORT_PIT_CMD         0x0008
+#define IO_PORT_PIT_CONTROL     0x0043
 #define IO_PORT_TIMER_MISC      0x0063
 
 // Hypervisor Capability.

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,6 +47,7 @@ const IO_PORT_DMA_PAGE3: u16 = 0x0083;
 const IO_PORT_VIDEO_MISC_B8: u16 = 0x00B8;
 const IO_PORT_SPECIAL_213: u16 = 0x0213;
 const IO_PORT_PIT_CMD: u16 = 0x0008;
+const IO_PORT_PIT_CONTROL: u16 = 0x0043;
 const IO_PORT_TIMER_MISC: u16 = 0x0063;
 
 fn port_name(port: u16) -> &'static str {
@@ -65,6 +66,7 @@ fn port_name(port: u16) -> &'static str {
         IO_PORT_DMA_PAGE3 => "DMA_PAGE3",
         IO_PORT_VIDEO_MISC_B8 => "VIDEO_MISC_B8",
         IO_PORT_SPECIAL_213 => "PORT_213",
+        IO_PORT_PIT_CONTROL => "PIT_CONTROL",
         IO_PORT_PIT_CMD => "PIT_CMD",
         IO_PORT_TIMER_MISC => "TIMER_MISC",
         _ => "UNKNOWN",
@@ -79,6 +81,7 @@ static mut UNKNOWN_PORT_COUNT: u32 = 0;
 static mut PIC_MASTER_IMR: u8 = 0;
 static mut PIC_SLAVE_IMR: u8 = 0;
 static mut SYS_CTRL: u8 = 0;
+static mut PIT_CONTROL: u8 = 0;
 static mut CGA_MODE: u8 = 0;
 static mut MDA_MODE: u8 = 0;
 
@@ -581,6 +584,9 @@ unsafe extern "system" fn emu_io_port_callback(
             } else if (*io_access).Port == IO_PORT_MDA_MODE {
                 (*io_access).Data = MDA_MODE as u32;
                 S_OK
+            } else if (*io_access).Port == IO_PORT_PIT_CONTROL {
+                (*io_access).Data = PIT_CONTROL as u32;
+                S_OK
             } else if (*io_access).Port == IO_PORT_PIC_MASTER_DATA {
                 (*io_access).Data = PIC_MASTER_IMR as u32;
                 S_OK
@@ -596,6 +602,7 @@ unsafe extern "system" fn emu_io_port_callback(
                 || (*io_access).Port == IO_PORT_VIDEO_MISC_B8
                 || (*io_access).Port == IO_PORT_SPECIAL_213
                 || (*io_access).Port == IO_PORT_PIT_CMD
+                || (*io_access).Port == IO_PORT_PIT_CONTROL
                 || (*io_access).Port == IO_PORT_TIMER_MISC
             {
                 (*io_access).Data = 0;
@@ -640,6 +647,9 @@ unsafe extern "system" fn emu_io_port_callback(
             } else if (*io_access).Port == IO_PORT_MDA_MODE {
                 MDA_MODE = (*io_access).Data as u8;
                 S_OK
+            } else if (*io_access).Port == IO_PORT_PIT_CONTROL {
+                PIT_CONTROL = (*io_access).Data as u8;
+                S_OK
             } else if (*io_access).Port == IO_PORT_PIC_MASTER_CMD {
                 PIC_MASTER_IMR = (*io_access).Data as u8; // treat command as IMR for simplicity
                 S_OK
@@ -656,6 +666,7 @@ unsafe extern "system" fn emu_io_port_callback(
                 || (*io_access).Port == IO_PORT_VIDEO_MISC_B8
                 || (*io_access).Port == IO_PORT_SPECIAL_213
                 || (*io_access).Port == IO_PORT_PIT_CMD
+                || (*io_access).Port == IO_PORT_PIT_CONTROL
                 || (*io_access).Port == IO_PORT_TIMER_MISC
             {
                 // These ports are touched by the BIOS during POST but


### PR DESCRIPTION
## Summary
- add PIT control port constant and variable
- track reads/writes to port 0x0043 in Rust and C implementations

## Testing
- `cargo test --target x86_64-pc-windows-gnu --quiet` *(fails: cannot compile due to missing Windows dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6878ff521510832ca27604c7196fe1f3