### PR TITLE
Patch BIOS loop by simulating PIT counter

### DIFF
--- a/SimpleWhpDemo/main.c
+++ b/SimpleWhpDemo/main.c
@@ -366,6 +366,8 @@ HRESULT SwEmulatorIoCallback(IN PVOID Context, IN OUT WHV_EMULATOR_IO_ACCESS_INF
                }
                else if (IoAccess->Port == IO_PORT_PIT_COUNTER1)
                {
+                       /* Simulate PIT channel 1 ticking so BIOS progress isn't stalled */
+                       PitCounter1--;
                        IoAccess->Data = PitCounter1;
                        return S_OK;
                }
@@ -444,6 +446,7 @@ HRESULT SwEmulatorIoCallback(IN PVOID Context, IN OUT WHV_EMULATOR_IO_ACCESS_INF
        }
        else if (IoAccess->Port == IO_PORT_PIT_COUNTER1)
        {
+               /* Reload channel 1 with a new counter start value */
                PitCounter1 = (UCHAR)IoAccess->Data;
                return S_OK;
        }

--- a/src/main.rs
+++ b/src/main.rs
@@ -592,6 +592,8 @@ unsafe extern "system" fn emu_io_port_callback(
                 (*io_access).Data = PIT_CONTROL as u32;
                 S_OK
             } else if (*io_access).Port == IO_PORT_PIT_COUNTER1 {
+                // Simulate ticking so BIOS doesn't loop forever
+                PIT_COUNTER1 = PIT_COUNTER1.wrapping_sub(1);
                 (*io_access).Data = PIT_COUNTER1 as u32;
                 S_OK
             } else if (*io_access).Port == IO_PORT_PIC_MASTER_DATA {
@@ -659,6 +661,7 @@ unsafe extern "system" fn emu_io_port_callback(
                 PIT_CONTROL = (*io_access).Data as u8;
                 S_OK
             } else if (*io_access).Port == IO_PORT_PIT_COUNTER1 {
+                // Reload start value for channel 1
                 PIT_COUNTER1 = (*io_access).Data as u8;
                 S_OK
             } else if (*io_access).Port == IO_PORT_PIC_MASTER_CMD {


### PR DESCRIPTION
## Summary
- emulate ticking of PIT channel 1 so BIOS loops break

## Testing
- `cargo check --target x86_64-pc-windows-gnu`
- `cargo test` *(fails: linker `x86_64-w64-mingw32-gcc` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687908226638832caeae8976aee64b56