### PR TITLE
Handle DMA temporary register

### DIFF
--- a/SimpleWhpDemo/main.c
+++ b/SimpleWhpDemo/main.c
@@ -274,6 +274,7 @@ static UCHAR MdaMode = 0;
 static UCHAR PitControl = 0;
 static UCHAR PitCounter0 = 0;
 static UCHAR PitCounter1 = 0;
+static UCHAR DmaTemp = 0;
 
 BOOL LoadDiskImage(PCSTR FileName)
 {
@@ -302,6 +303,7 @@ static const char* GetPortName(USHORT port)
         case IO_PORT_MDA_MODE:        return "MDA_MODE";
         case IO_PORT_CGA_MODE:        return "CGA_MODE";
         case IO_PORT_DMA_PAGE3:       return "DMA_PAGE3";
+       case IO_PORT_DMA_TEMP:        return "DMA_TEMP";
        case IO_PORT_VIDEO_MISC_B8:   return "VIDEO_MISC_B8";
        case IO_PORT_SPECIAL_213:     return "PORT_213";
        case IO_PORT_PIT_COUNTER0:    return "PIT_COUNTER0";
@@ -359,6 +361,11 @@ HRESULT SwEmulatorIoCallback(IN PVOID Context, IN OUT WHV_EMULATOR_IO_ACCESS_INF
                else if (IoAccess->Port == IO_PORT_CGA_MODE)
                {
                        IoAccess->Data = CgaMode;
+                       return S_OK;
+               }
+               else if (IoAccess->Port == IO_PORT_DMA_TEMP)
+               {
+                       IoAccess->Data = DmaTemp;
                        return S_OK;
                }
                else if (IoAccess->Port == IO_PORT_PIT_CONTROL)
@@ -466,11 +473,16 @@ HRESULT SwEmulatorIoCallback(IN PVOID Context, IN OUT WHV_EMULATOR_IO_ACCESS_INF
                PitCounter1 = (UCHAR)IoAccess->Data;
                return S_OK;
        }
+       else if (IoAccess->Port == IO_PORT_DMA_TEMP)
+       {
+               DmaTemp = (UCHAR)IoAccess->Data;
+               return S_OK;
+       }
        else if (IoAccess->Port == IO_PORT_PIC_MASTER_CMD)
-        {
-                PicMasterImr = (UCHAR)IoAccess->Data; /* treat command as IMR for simplicity */
-                return S_OK;
-        }
+       {
+               PicMasterImr = (UCHAR)IoAccess->Data; /* treat command as IMR for simplicity */
+               return S_OK;
+       }
         else if (IoAccess->Port == IO_PORT_PIC_SLAVE_CMD)
         {
                 PicSlaveImr = (UCHAR)IoAccess->Data;

--- a/SimpleWhpDemo/vmdef.h
+++ b/SimpleWhpDemo/vmdef.h
@@ -18,6 +18,7 @@
 #define IO_PORT_VIDEO_MISC_B8   0x00B8
 #define IO_PORT_SPECIAL_213     0x0213
 #define IO_PORT_PIT_CMD         0x0008
+#define IO_PORT_DMA_TEMP        0x000D
 #define IO_PORT_PIT_COUNTER0    0x0040
 #define IO_PORT_PIT_COUNTER1    0x0041
 #define IO_PORT_PIT_CONTROL     0x0043

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,6 +47,7 @@ const IO_PORT_DMA_PAGE3: u16 = 0x0083;
 const IO_PORT_VIDEO_MISC_B8: u16 = 0x00B8;
 const IO_PORT_SPECIAL_213: u16 = 0x0213;
 const IO_PORT_PIT_CMD: u16 = 0x0008;
+const IO_PORT_DMA_TEMP: u16 = 0x000D;
 const IO_PORT_PIT_COUNTER0: u16 = 0x0040;
 const IO_PORT_PIT_COUNTER1: u16 = 0x0041;
 const IO_PORT_PIT_CONTROL: u16 = 0x0043;
@@ -68,6 +69,7 @@ fn port_name(port: u16) -> &'static str {
         IO_PORT_DMA_PAGE3 => "DMA_PAGE3",
         IO_PORT_VIDEO_MISC_B8 => "VIDEO_MISC_B8",
         IO_PORT_SPECIAL_213 => "PORT_213",
+        IO_PORT_DMA_TEMP => "DMA_TEMP",
         IO_PORT_PIT_COUNTER0 => "PIT_COUNTER0",
         IO_PORT_PIT_COUNTER1 => "PIT_COUNTER1",
         IO_PORT_PIT_CONTROL => "PIT_CONTROL",
@@ -90,6 +92,7 @@ static mut PIT_COUNTER0: u8 = 0;
 static mut PIT_COUNTER1: u8 = 0;
 static mut CGA_MODE: u8 = 0;
 static mut MDA_MODE: u8 = 0;
+static mut DMA_TEMP: u8 = 0;
 
 const CGA_COLS: usize = 80;
 const CGA_ROWS: usize = 25;
@@ -591,6 +594,9 @@ unsafe extern "system" fn emu_io_port_callback(
             } else if (*io_access).Port == IO_PORT_MDA_MODE {
                 (*io_access).Data = MDA_MODE as u32;
                 S_OK
+            } else if (*io_access).Port == IO_PORT_DMA_TEMP {
+                (*io_access).Data = DMA_TEMP as u32;
+                S_OK
             } else if (*io_access).Port == IO_PORT_PIT_CONTROL {
                 (*io_access).Data = PIT_CONTROL as u32;
                 S_OK
@@ -676,6 +682,9 @@ unsafe extern "system" fn emu_io_port_callback(
             } else if (*io_access).Port == IO_PORT_PIT_COUNTER1 {
                 // Reload start value for channel 1
                 PIT_COUNTER1 = (*io_access).Data as u8;
+                S_OK
+            } else if (*io_access).Port == IO_PORT_DMA_TEMP {
+                DMA_TEMP = (*io_access).Data as u8;
                 S_OK
             } else if (*io_access).Port == IO_PORT_PIC_MASTER_CMD {
                 PIC_MASTER_IMR = (*io_access).Data as u8; // treat command as IMR for simplicity


### PR DESCRIPTION
## Summary
- emulate DMA temporary register at port `0x000D`
- add handling for C implementation

## Testing
- `cargo fmt -- --check`
- `cargo test` *(fails: could not find `Win32` in `windows`)*

------
https://chatgpt.com/codex/tasks/task_e_68790e8ab040832cae59a05d85d214a2