### PR TITLE
Add DMA mode register port emulation

### DIFF
--- a/SimpleWhpDemo/main.c
+++ b/SimpleWhpDemo/main.c
@@ -275,6 +275,7 @@ static UCHAR PitControl = 0;
 static UCHAR PitCounter0 = 0;
 static UCHAR PitCounter1 = 0;
 static UCHAR DmaTemp = 0;
+static UCHAR DmaMode = 0;
 
 BOOL LoadDiskImage(PCSTR FileName)
 {
@@ -304,6 +305,7 @@ static const char* GetPortName(USHORT port)
         case IO_PORT_SYS_CTRL:        return "SYS_CTRL";
         case IO_PORT_MDA_MODE:        return "MDA_MODE";
         case IO_PORT_CGA_MODE:        return "CGA_MODE";
+        case IO_PORT_DMA_MODE:       return "DMA_MODE";
         case IO_PORT_DMA_PAGE3:       return "DMA_PAGE3";
        case IO_PORT_DMA_TEMP:        return "DMA_TEMP";
        case IO_PORT_VIDEO_MISC_B8:   return "VIDEO_MISC_B8";
@@ -363,6 +365,11 @@ HRESULT SwEmulatorIoCallback(IN PVOID Context, IN OUT WHV_EMULATOR_IO_ACCESS_INF
                else if (IoAccess->Port == IO_PORT_MDA_MODE)
                {
                        IoAccess->Data = MdaMode;
+                       return S_OK;
+               }
+               else if (IoAccess->Port == IO_PORT_DMA_MODE)
+               {
+                       IoAccess->Data = DmaMode;
                        return S_OK;
                }
                else if (IoAccess->Port == IO_PORT_CGA_MODE)
@@ -456,6 +463,11 @@ HRESULT SwEmulatorIoCallback(IN PVOID Context, IN OUT WHV_EMULATOR_IO_ACCESS_INF
        else if (IoAccess->Port == IO_PORT_MDA_MODE)
        {
                MdaMode = (UCHAR)IoAccess->Data;
+               return S_OK;
+       }
+       else if (IoAccess->Port == IO_PORT_DMA_MODE)
+       {
+               DmaMode = (UCHAR)IoAccess->Data;
                return S_OK;
        }
        else if (IoAccess->Port == IO_PORT_CGA_MODE)

--- a/SimpleWhpDemo/vmdef.h
+++ b/SimpleWhpDemo/vmdef.h
@@ -20,6 +20,7 @@
 #define IO_PORT_VIDEO_MISC_B8   0x00B8
 #define IO_PORT_SPECIAL_213     0x0213
 #define IO_PORT_PIT_CMD         0x0008
+#define IO_PORT_DMA_MODE        0x000B
 #define IO_PORT_DMA_TEMP        0x000D
 #define IO_PORT_PIT_COUNTER0    0x0040
 #define IO_PORT_PIT_COUNTER1    0x0041

--- a/readme.md
+++ b/readme.md
@@ -49,6 +49,7 @@ emulator logs each I/O access so you can observe the guest's behavior.
 | `0x00FF` | Disk data port backed by `disk.img`. Reads/writes stream sequential bytes. |
 | `0x0080` | POST/IO‑delay port. Writes are ignored but recorded in the log. |
 | `0x0061` | System control port used for speaker and NMI masking. |
+| `0x000B` | DMA mode register for the 8237 controller. Reads return the last value written. |
 | `0x03B8` | MDA mode control register. Reads return the last value written. |
 | `0x03D8` | CGA mode control register. Reads return the last value written. |
 | other | Any other port triggers an `Unknown I/O Port` message. Repeated access to the same unknown port terminates the program. |

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,7 @@ const IO_PORT_SYS_CTRL: u16 = 0x0061;
 const IO_PORT_MDA_MODE: u16 = 0x03B8;
 const IO_PORT_CGA_MODE: u16 = 0x03D8;
 const IO_PORT_DMA_PAGE3: u16 = 0x0083;
+const IO_PORT_DMA_MODE: u16 = 0x000B;
 const IO_PORT_VIDEO_MISC_B8: u16 = 0x00B8;
 const IO_PORT_SPECIAL_213: u16 = 0x0213;
 const IO_PORT_PIT_CMD: u16 = 0x0008;
@@ -71,6 +72,7 @@ fn port_name(port: u16) -> &'static str {
         IO_PORT_MDA_MODE => "MDA_MODE",
         IO_PORT_CGA_MODE => "CGA_MODE",
         IO_PORT_DMA_PAGE3 => "DMA_PAGE3",
+        IO_PORT_DMA_MODE => "DMA_MODE",
         IO_PORT_VIDEO_MISC_B8 => "VIDEO_MISC_B8",
         IO_PORT_SPECIAL_213 => "PORT_213",
         IO_PORT_DMA_TEMP => "DMA_TEMP",
@@ -97,6 +99,7 @@ static mut PIT_COUNTER1: u8 = 0;
 static mut CGA_MODE: u8 = 0;
 static mut MDA_MODE: u8 = 0;
 static mut DMA_TEMP: u8 = 0;
+static mut DMA_MODE: u8 = 0;
 
 const CGA_COLS: usize = 80;
 const CGA_ROWS: usize = 25;
@@ -601,6 +604,9 @@ unsafe extern "system" fn emu_io_port_callback(
             } else if (*io_access).Port == IO_PORT_MDA_MODE {
                 (*io_access).Data = MDA_MODE as u32;
                 S_OK
+            } else if (*io_access).Port == IO_PORT_DMA_MODE {
+                (*io_access).Data = DMA_MODE as u32;
+                S_OK
             } else if (*io_access).Port == IO_PORT_DMA_TEMP {
                 (*io_access).Data = DMA_TEMP as u32;
                 S_OK
@@ -689,6 +695,9 @@ unsafe extern "system" fn emu_io_port_callback(
             } else if (*io_access).Port == IO_PORT_PIT_COUNTER1 {
                 // Reload start value for channel 1
                 PIT_COUNTER1 = (*io_access).Data as u8;
+                S_OK
+            } else if (*io_access).Port == IO_PORT_DMA_MODE {
+                DMA_MODE = (*io_access).Data as u8;
                 S_OK
             } else if (*io_access).Port == IO_PORT_DMA_TEMP {
                 DMA_TEMP = (*io_access).Data as u8;


### PR DESCRIPTION
## Summary
- support DMA mode register I/O port (0x000B) in the C emulator
- expose the new port constant in `vmdef.h`
- document the DMA mode register in the README

## Testing
- `cargo check --target x86_64-pc-windows-gnu`

------
https://chatgpt.com/codex/tasks/task_e_6879161aac34832cbd20cfa189e4980b