### PR TITLE
Add DMA mask port support

### DIFF
--- a/SimpleWhpDemo/main.c
+++ b/SimpleWhpDemo/main.c
@@ -276,6 +276,7 @@ static UCHAR PitCounter0 = 0;
 static UCHAR PitCounter1 = 0;
 static UCHAR DmaTemp = 0;
 static UCHAR DmaMode = 0;
+static UCHAR DmaMask = 0;
 
 BOOL LoadDiskImage(PCSTR FileName)
 {
@@ -306,6 +307,7 @@ static const char* GetPortName(USHORT port)
         case IO_PORT_MDA_MODE:        return "MDA_MODE";
         case IO_PORT_CGA_MODE:        return "CGA_MODE";
         case IO_PORT_DMA_MODE:       return "DMA_MODE";
+        case IO_PORT_DMA_MASK:       return "DMA_MASK";
         case IO_PORT_DMA_PAGE3:       return "DMA_PAGE3";
        case IO_PORT_DMA_TEMP:        return "DMA_TEMP";
        case IO_PORT_VIDEO_MISC_B8:   return "VIDEO_MISC_B8";
@@ -365,6 +367,11 @@ HRESULT SwEmulatorIoCallback(IN PVOID Context, IN OUT WHV_EMULATOR_IO_ACCESS_INF
                else if (IoAccess->Port == IO_PORT_MDA_MODE)
                {
                        IoAccess->Data = MdaMode;
+                       return S_OK;
+               }
+               else if (IoAccess->Port == IO_PORT_DMA_MASK)
+               {
+                       IoAccess->Data = DmaMask;
                        return S_OK;
                }
                else if (IoAccess->Port == IO_PORT_DMA_MODE)
@@ -463,6 +470,11 @@ HRESULT SwEmulatorIoCallback(IN PVOID Context, IN OUT WHV_EMULATOR_IO_ACCESS_INF
        else if (IoAccess->Port == IO_PORT_MDA_MODE)
        {
                MdaMode = (UCHAR)IoAccess->Data;
+               return S_OK;
+       }
+       else if (IoAccess->Port == IO_PORT_DMA_MASK)
+       {
+               DmaMask = (UCHAR)IoAccess->Data;
                return S_OK;
        }
        else if (IoAccess->Port == IO_PORT_DMA_MODE)

--- a/SimpleWhpDemo/vmdef.h
+++ b/SimpleWhpDemo/vmdef.h
@@ -17,6 +17,7 @@
 #define IO_PORT_MDA_MODE        0x03B8
 #define IO_PORT_CGA_MODE        0x03D8
 #define IO_PORT_DMA_PAGE3       0x0083
+#define IO_PORT_DMA_MASK        0x000A
 #define IO_PORT_VIDEO_MISC_B8   0x00B8
 #define IO_PORT_SPECIAL_213     0x0213
 #define IO_PORT_PIT_CMD         0x0008

--- a/readme.md
+++ b/readme.md
@@ -49,6 +49,7 @@ emulator logs each I/O access so you can observe the guest's behavior.
 | `0x00FF` | Disk data port backed by `disk.img`. Reads/writes stream sequential bytes. |
 | `0x0080` | POST/IO‑delay port. Writes are ignored but recorded in the log. |
 | `0x0061` | System control port used for speaker and NMI masking. |
+| `0x000A` | DMA single-channel mask register. Reads return the last value written. |
 | `0x000B` | DMA mode register for the 8237 controller. Reads return the last value written. |
 | `0x03B8` | MDA mode control register. Reads return the last value written. |
 | `0x03D8` | CGA mode control register. Reads return the last value written. |

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,7 @@ const IO_PORT_SYS_CTRL: u16 = 0x0061;
 const IO_PORT_MDA_MODE: u16 = 0x03B8;
 const IO_PORT_CGA_MODE: u16 = 0x03D8;
 const IO_PORT_DMA_PAGE3: u16 = 0x0083;
+const IO_PORT_DMA_MASK: u16 = 0x000A;
 const IO_PORT_DMA_MODE: u16 = 0x000B;
 const IO_PORT_VIDEO_MISC_B8: u16 = 0x00B8;
 const IO_PORT_SPECIAL_213: u16 = 0x0213;
@@ -72,6 +73,7 @@ fn port_name(port: u16) -> &'static str {
         IO_PORT_MDA_MODE => "MDA_MODE",
         IO_PORT_CGA_MODE => "CGA_MODE",
         IO_PORT_DMA_PAGE3 => "DMA_PAGE3",
+        IO_PORT_DMA_MASK => "DMA_MASK",
         IO_PORT_DMA_MODE => "DMA_MODE",
         IO_PORT_VIDEO_MISC_B8 => "VIDEO_MISC_B8",
         IO_PORT_SPECIAL_213 => "PORT_213",
@@ -100,6 +102,7 @@ static mut CGA_MODE: u8 = 0;
 static mut MDA_MODE: u8 = 0;
 static mut DMA_TEMP: u8 = 0;
 static mut DMA_MODE: u8 = 0;
+static mut DMA_MASK: u8 = 0;
 
 const CGA_COLS: usize = 80;
 const CGA_ROWS: usize = 25;
@@ -604,6 +607,9 @@ unsafe extern "system" fn emu_io_port_callback(
             } else if (*io_access).Port == IO_PORT_MDA_MODE {
                 (*io_access).Data = MDA_MODE as u32;
                 S_OK
+            } else if (*io_access).Port == IO_PORT_DMA_MASK {
+                (*io_access).Data = DMA_MASK as u32;
+                S_OK
             } else if (*io_access).Port == IO_PORT_DMA_MODE {
                 (*io_access).Data = DMA_MODE as u32;
                 S_OK
@@ -684,6 +690,9 @@ unsafe extern "system" fn emu_io_port_callback(
                 S_OK
             } else if (*io_access).Port == IO_PORT_MDA_MODE {
                 MDA_MODE = (*io_access).Data as u8;
+                S_OK
+            } else if (*io_access).Port == IO_PORT_DMA_MASK {
+                DMA_MASK = (*io_access).Data as u8;
                 S_OK
             } else if (*io_access).Port == IO_PORT_PIT_CONTROL {
                 PIT_CONTROL = (*io_access).Data as u8;


### PR DESCRIPTION
## Summary
- handle I/O port `0x000A` (DMA mask register) in the C emulator
- document the new constant in `vmdef.h`

## Testing
- `cargo check --target x86_64-pc-windows-gnu`
- `cargo test` *(fails: could not find `Win32` in `windows`)*

------
https://chatgpt.com/codex/tasks/task_e_68791aea76c0832ca68fbd305db5e321