### PR TITLE
Handle MDA CRTC ports

### DIFF
--- a/SimpleWhpDemo/main.c
+++ b/SimpleWhpDemo/main.c
@@ -271,6 +271,8 @@ static UCHAR PicSlaveImr = 0;
 static UCHAR SysCtrl = 0;
 static UCHAR CgaMode = 0;
 static UCHAR MdaMode = 0;
+static UCHAR MdaCrtcIndex = 0;
+static UCHAR MdaCrtcRegs[32] = {0};
 static UCHAR PitControl = 0;
 static UCHAR PitCounter0 = 0;
 static UCHAR PitCounter1 = 0;
@@ -306,6 +308,8 @@ static const char* GetPortName(USHORT port)
         case IO_PORT_PIC_SLAVE_DATA:  return "PIC_SLAVE_DATA";
         case IO_PORT_SYS_CTRL:        return "SYS_CTRL";
         case IO_PORT_SYS_PORTC:       return "SYS_PORTC";
+        case IO_PORT_MDA_CRTC_IDX:    return "MDA_CRTC_IDX";
+        case IO_PORT_MDA_CRTC_DATA:   return "MDA_CRTC_DATA";
         case IO_PORT_MDA_MODE:        return "MDA_MODE";
         case IO_PORT_CGA_MODE:        return "CGA_MODE";
         case IO_PORT_DMA_MODE:       return "DMA_MODE";
@@ -377,6 +381,17 @@ HRESULT SwEmulatorIoCallback(IN PVOID Context, IN OUT WHV_EMULATOR_IO_ACCESS_INF
                else if (IoAccess->Port == IO_PORT_MDA_MODE)
                {
                        IoAccess->Data = MdaMode;
+                       return S_OK;
+               }
+               else if (IoAccess->Port == IO_PORT_MDA_CRTC_IDX)
+               {
+                       IoAccess->Data = MdaCrtcIndex;
+                       return S_OK;
+               }
+               else if (IoAccess->Port == IO_PORT_MDA_CRTC_DATA)
+               {
+                       UCHAR idx = MdaCrtcIndex & 0x1F;
+                       IoAccess->Data = MdaCrtcRegs[idx];
                        return S_OK;
                }
                else if (IoAccess->Port == IO_PORT_DMA_MASK)
@@ -484,6 +499,17 @@ HRESULT SwEmulatorIoCallback(IN PVOID Context, IN OUT WHV_EMULATOR_IO_ACCESS_INF
        else if (IoAccess->Port == IO_PORT_MDA_MODE)
        {
                MdaMode = (UCHAR)IoAccess->Data;
+               return S_OK;
+       }
+       else if (IoAccess->Port == IO_PORT_MDA_CRTC_IDX)
+       {
+               MdaCrtcIndex = ((UCHAR)IoAccess->Data) & 0x1F;
+               return S_OK;
+       }
+       else if (IoAccess->Port == IO_PORT_MDA_CRTC_DATA)
+       {
+               UCHAR idx = MdaCrtcIndex & 0x1F;
+               MdaCrtcRegs[idx] = (UCHAR)IoAccess->Data;
                return S_OK;
        }
        else if (IoAccess->Port == IO_PORT_DMA_MASK)

--- a/SimpleWhpDemo/vmdef.h
+++ b/SimpleWhpDemo/vmdef.h
@@ -15,6 +15,8 @@
 #define IO_PORT_SYS_PORTC       0x0062
 #define IO_PORT_PIC_SLAVE_CMD   0x00A0
 #define IO_PORT_PIC_SLAVE_DATA  0x00A1
+#define IO_PORT_MDA_CRTC_IDX    0x03B4
+#define IO_PORT_MDA_CRTC_DATA   0x03B5
 #define IO_PORT_MDA_MODE        0x03B8
 #define IO_PORT_CGA_MODE        0x03D8
 #define IO_PORT_DMA_PAGE3       0x0083

--- a/readme.md
+++ b/readme.md
@@ -51,6 +51,8 @@ emulator logs each I/O access so you can observe the guest's behavior.
 | `0x0061` | System control port used for speaker and NMI masking. |
 | `0x000A` | DMA single-channel mask register. Reads return the last value written. |
 | `0x000B` | DMA mode register for the 8237 controller. Reads return the last value written. |
+| `0x03B4` | MDA CRTC index register. Reads return the last value written. |
+| `0x03B5` | MDA CRTC data register. Each indexed register retains the last value written. |
 | `0x03B8` | MDA mode control register. Reads return the last value written. |
 | `0x03D8` | CGA mode control register. Reads return the last value written. |
 | other | Any other port triggers an `Unknown I/O Port` message. Repeated access to the same unknown port terminates the program. |


### PR DESCRIPTION
## Summary
- support MDA CRTC index/data ports in `main.c`
- add corresponding constants to `vmdef.h`

## Testing
- `cargo test --target x86_64-pc-windows-gnu` *(fails: target may not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_6879228e8990832c977b35e990e2f3c5