### PR TITLE
Add PC speaker beep demo

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -22,7 +22,15 @@ fn main() {
         .arg("keyboard.lst")
         .status()
         .unwrap();
+    Command::new("nasm")
+        .args(&["-f", "bin", "tests/beep.asm", "-o"])
+        .arg("beep.com")
+        .arg("-l")
+        .arg("beep.lst")
+        .status()
+        .unwrap();
     println!("cargo::rerun-if-changed=tests/ivt.asm");
     println!("cargo::rerun-if-changed=tests/hello_dos.asm");
     println!("cargo::rerun-if-changed=tests/keyboard.asm");
+    println!("cargo::rerun-if-changed=tests/beep.asm");
 }

--- a/readme.md
+++ b/readme.md
@@ -64,6 +64,14 @@ nasm -f bin tests\keyboard.asm -o keyboard.com -l keyboard.lst
 SimpleWhpDemo.exe keyboard.com
 ```
 
+### Speaker beep demo
+The `beep.asm` example writes `0x03` to port `0x61` to sound the speaker.
+Assemble and run it with:
+```bat
+nasm -f bin tests\beep.asm -o beep.com -l beep.lst
+SimpleWhpDemo.exe beep.com
+```
+
 Always run the hypervisor with the assembled `.com` file rather than the source
 `*.asm` to avoid spurious "Input is not implemented" messages.
 

--- a/tests/beep.asm
+++ b/tests/beep.asm
@@ -1,0 +1,16 @@
+bits 16
+org 0x100
+
+%define speaker_port 0x61
+
+segment .text
+start:
+        mov al, 3
+        out speaker_port, al
+        mov cx, 0xFFFF
+.delay:
+        loop .delay
+        mov al, 0
+        out speaker_port, al
+        cli
+        hlt


### PR DESCRIPTION
## Summary
- add `beep.asm` example that toggles port `0x61`
- assemble `beep.asm` in `build.rs`
- document beep demo in `readme`

## Testing
- `nasm -f bin tests/beep.asm -o beep.com -l beep.lst`
- `cargo build --target x86_64-pc-windows-gnu` *(fails: linking with `x86_64-w64-mingw32-gcc` failed)*

------
https://chatgpt.com/codex/tasks/task_e_687976d217d0832c84e8331109520686