### PR TITLE
Make OpenAL optional

### DIFF
--- a/SimpleWhpDemo/main.c
+++ b/SimpleWhpDemo/main.c
@@ -3,8 +3,13 @@
 #include <Windows.h>
 #include <WinHvPlatform.h>
 #include <WinHvEmulation.h>
-#include <AL/al.h>
-#include <AL/alc.h>
+#if __has_include(<AL/al.h>) && __has_include(<AL/alc.h>)
+#   include <AL/al.h>
+#   include <AL/alc.h>
+#   define SW_HAVE_OPENAL 1
+#else
+#   define SW_HAVE_OPENAL 0
+#endif
 #include "vmdef.h"
 
 #define CGA_COLS 80
@@ -14,6 +19,7 @@
 static USHORT CgaBuffer[CGA_COLS*CGA_ROWS];
 static UINT32 CgaCursor = 0;
 
+#if SW_HAVE_OPENAL
 static void OpenalBeep(DWORD freq, DWORD dur_ms)
 {
         ALCdevice* device = alcOpenDevice(NULL);
@@ -56,6 +62,13 @@ static void OpenalBeep(DWORD freq, DWORD dur_ms)
         alcDestroyContext(context);
         alcCloseDevice(device);
 }
+#else
+static void OpenalBeep(DWORD freq, DWORD dur_ms)
+{
+        UNREFERENCED_PARAMETER(freq);
+        UNREFERENCED_PARAMETER(dur_ms);
+}
+#endif
 
 static void CgaPutChar(char ch)
 {

--- a/readme.md
+++ b/readme.md
@@ -19,6 +19,9 @@ The underlying API is the same one used by the WHPX accelerator for QEMU, so eve
 
 ## Build
 To build this project, you are required to install [VS2022](https://visualstudio.microsoft.com/) and [Windows SDK](https://developer.microsoft.com/en-us/windows/downloads/windows-10-sdk/).
+In addition, the C version relies on the OpenAL headers and libraries. You can
+obtain them by installing [OpenAL Soft](https://openal-soft.org/) via
+[vcpkg](https://github.com/microsoft/vcpkg) or any other package manager.
 
 To build test cases, you are required to install [NASM](https://nasm.us/). \
 Run the following command to build a test case:


### PR DESCRIPTION
## Summary
- make OpenAL optional in `main.c`
- document OpenAL requirement for the C build

## Testing
- `cargo check --target x86_64-pc-windows-gnu --quiet`

------
https://chatgpt.com/codex/tasks/task_e_687980961e08832cb9d4e3b7f26cc7ec