### PR TITLE
Add startup beep to verify audio

### DIFF
--- a/SimpleWhpDemo/main.c
+++ b/SimpleWhpDemo/main.c
@@ -1014,6 +1014,10 @@ int main(int argc, char* argv[], char* envp[])
 {
        puts("SimpleWhpDemo version 1.1.1");
        puts("IVT firmware version 0.1.0");
+#if SW_HAVE_OPENAL
+       /* Emit a short beep so sound output can be verified right away. */
+       OpenalBeep(750, 60);
+#endif
        PSTR ProgramFileName = argc >= 2 ? argv[1] : "hello.com";
        PSTR BiosFileName = argc >= 3 ? argv[2] : DEFAULT_BIOS;
 	SwCheckSystemHypervisor();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1163,6 +1163,8 @@ fn init_whpx() -> HRESULT {
 fn main() {
     println!("SimpleWhpDemo version {}", env!("CARGO_PKG_VERSION"));
     println!("IVT firmware version 0.1.0");
+    // Emit a short beep so sound output can be verified right away.
+    openal_beep(750, 60);
     let args: Vec<String> = std::env::args().collect();
     let program = args.get(1).map(String::as_str).unwrap_or("hello.com");
     let bios = args.get(2).map(String::as_str).unwrap_or(DEFAULT_BIOS);


### PR DESCRIPTION
## Summary
- call `OpenalBeep()` at the start of the C version

## Testing
- `cargo check --target x86_64-pc-windows-gnu`


------
https://chatgpt.com/codex/tasks/task_e_687986c6e414832ca9e2c8431468de21