### PR TITLE
Unify beep length in C implementation

### DIFF
--- a/SimpleWhpDemo/main.c
+++ b/SimpleWhpDemo/main.c
@@ -17,6 +17,8 @@
 #define CGA_ROWS 25
 #define DEFAULT_BIOS "ami_8088_bios_31jan89.bin"
 #define FALLBACK_BIOS "ivt.fw"
+/* Duration for the startup beep and speaker output, in milliseconds */
+#define BEEP_DURATION_MS 300
 static USHORT CgaBuffer[CGA_COLS*CGA_ROWS];
 static UINT32 CgaCursor = 0;
 
@@ -699,8 +701,8 @@ HRESULT SwEmulatorIoCallback(IN PVOID Context, IN OUT WHV_EMULATOR_IO_ACCESS_INF
                if (new_state && !SpeakerOn)
                {
                        DWORD freq = PitCounter2 ? 1193182 / PitCounter2 : 750;
-                       Beep(freq, 60);
-                       OpenalBeep(freq, 60);
+                      Beep(freq, BEEP_DURATION_MS);
+                      OpenalBeep(freq, BEEP_DURATION_MS);
                }
                SpeakerOn = new_state;
                return S_OK;
@@ -1021,7 +1023,7 @@ int main(int argc, char* argv[], char* envp[])
         * initialization. This helps confirm that OpenAL output works
         * before any other emulation happens.
         */
-       OpenalBeep(1000, 300);
+       OpenalBeep(1000, BEEP_DURATION_MS);
 #endif
        PSTR ProgramFileName = argc >= 2 ? argv[1] : "hello.com";
        PSTR BiosFileName = argc >= 3 ? argv[2] : DEFAULT_BIOS;

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,9 @@ const DEFAULT_BIOS: &str = "ami_8088_bios_31jan89.bin\0";
 const FALLBACK_BIOS: &str = "ivt.fw\0";
 const GUEST_MEM_SIZE: usize = 0x100000;
 
+/// Duration for the startup beep and speaker output in milliseconds.
+const BEEP_DURATION_MS: u32 = 300;
+
 fn openal_beep(freq: u32, dur_ms: u32) {
     unsafe {
         let device = al::alcOpenDevice(std::ptr::null());
@@ -901,8 +904,8 @@ unsafe extern "system" fn emu_io_port_callback(
                     } else {
                         750
                     };
-                    let _ = Beep(freq, 60);
-                    openal_beep(freq, 60);
+                    let _ = Beep(freq, BEEP_DURATION_MS);
+                    openal_beep(freq, BEEP_DURATION_MS);
                 }
                 SPEAKER_ON = new_state;
                 S_OK
@@ -1170,7 +1173,7 @@ fn main() {
 
     // Emit a slightly longer beep so the audio device has time to start up.
     // This helps confirm OpenAL is working before emulation proceeds.
-    openal_beep(1000, 300);
+    openal_beep(1000, BEEP_DURATION_MS);
     let args: Vec<String> = std::env::args().collect();
     let program = args.get(1).map(String::as_str).unwrap_or("hello.com");
     let bios = args.get(2).map(String::as_str).unwrap_or(DEFAULT_BIOS);


### PR DESCRIPTION
## Summary
- define `BEEP_DURATION_MS` in `main.c`
- use the constant for speaker output and startup tone

## Testing
- `cargo check` *(fails: WHV_* and Win32 APIs missing)*

------
https://chatgpt.com/codex/tasks/task_e_6879949983b8832ca3d2ae3501ddcf8c