### PR TITLE
Fix PIT variable declarations

### DIFF
--- a/SimpleWhpDemo/main.c
+++ b/SimpleWhpDemo/main.c
@@ -132,6 +132,21 @@ static void OpenalBeep(DWORD freq, DWORD dur_ms)
 }
 #endif
 
+/* Programmable Interval Timer (PIT) definitions */
+#define PIT_FREQUENCY 1193182ULL
+typedef struct {
+        USHORT Count;
+        USHORT Reload;
+        UCHAR  Mode;
+        UCHAR  Access;
+        BOOLEAN Bcd;
+        BOOLEAN Latched;
+        USHORT Latch;
+        BOOLEAN RwLow;
+} PIT_CHANNEL;
+static PIT_CHANNEL PitChannels[3] = {0};
+static ULONGLONG PitLastUpdate = 0;
+
 static void UpdatePit(void)
 {
         ULONGLONG now = GetTickCount64();
@@ -560,19 +575,6 @@ static UCHAR SysCtrl = 0;
 static UCHAR CgaMode = 0;
 static UCHAR MdaMode = 0;
 static UCHAR PitControl = 0;
-#define PIT_FREQUENCY 1193182ULL
-typedef struct {
-        USHORT Count;
-        USHORT Reload;
-        UCHAR  Mode;
-        UCHAR  Access;
-        BOOLEAN Bcd;
-        BOOLEAN Latched;
-        USHORT Latch;
-        BOOLEAN RwLow;
-} PIT_CHANNEL;
-static PIT_CHANNEL PitChannels[3] = {0};
-static ULONGLONG PitLastUpdate = 0;
 static UCHAR DmaTemp = 0;
 static UCHAR DmaMode = 0;
 static UCHAR DmaMask = 0;


### PR DESCRIPTION
## Summary
- define `PIT_CHANNEL` data structure and related globals before using them in functions
- remove old duplicate declarations

## Testing
- `cargo test --quiet` *(fails: feature `edition2024` is not stabilized)*

------
https://chatgpt.com/codex/tasks/task_e_687d10d902bc832c82102c20f691c954